### PR TITLE
Add minimal macOS receipt tracker

### DIFF
--- a/Models/Receipt.swift
+++ b/Models/Receipt.swift
@@ -1,0 +1,20 @@
+import Foundation
+import CoreData
+
+/// Core Data entity representing a receipt.
+@objc(Receipt)
+public class Receipt: NSManagedObject, Identifiable {
+    @NSManaged public var id: UUID
+    @NSManaged public var vendor: String?
+    @NSManaged public var total: NSDecimalNumber?
+    @NSManaged public var date: Date?
+    @NSManaged public var tags: [String]?
+    @NSManaged public var imagePath: String
+    @NSManaged public var createdAt: Date
+}
+
+extension Receipt {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Receipt> {
+        return NSFetchRequest<Receipt>(entityName: "Receipt")
+    }
+}

--- a/Models/ReceiptModel.xcdatamodeld/.xccurrentversion
+++ b/Models/ReceiptModel.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>_XCCurrentVersionName</key>
+    <string>ReceiptModel.xcdatamodel</string>
+</dict>
+</plist>

--- a/Models/ReceiptModel.xcdatamodeld/ReceiptModel.xcdatamodel/contents
+++ b/Models/ReceiptModel.xcdatamodeld/ReceiptModel.xcdatamodel/contents
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17710" systemVersion="20A2408" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Receipt" representedClassName="Receipt" syncable="YES" codeGenerationType="class">
+        <attribute name="id" optional="NO" attributeType="UUID"/>
+        <attribute name="vendor" optional="YES" attributeType="String"/>
+        <attribute name="total" optional="YES" attributeType="Decimal"/>
+        <attribute name="date" optional="YES" attributeType="Date"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
+        <attribute name="imagePath" optional="NO" attributeType="String"/>
+        <attribute name="createdAt" optional="NO" attributeType="Date"/>
+    </entity>
+    <elements>
+        <element name="Receipt" positionX="160" positionY="160" width="128" height="128"/>
+    </elements>
+</model>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:6.1
+import PackageDescription
+
+let package = Package(
+    name: "ReceiptApp",
+    platforms: [
+        .macOS(.v11)
+    ],
+    products: [
+        .executable(name: "ReceiptApp", targets: ["ReceiptApp"])
+    ],
+    dependencies: [],
+    targets: [
+        .executableTarget(
+            name: "ReceiptApp",
+            dependencies: [],
+            path: ".",
+            sources: ["Sources", "Models/Receipt.swift", "Services", "Views"],
+            resources: [
+                .process("Models/ReceiptModel.xcdatamodeld")
+            ]
+        ),
+        .testTarget(
+            name: "ReceiptAppTests",
+            dependencies: ["ReceiptApp"],
+            path: "Tests"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# TESTING
-Just a test
+# ReceiptApp
+
+Minimal macOS receipt tracker built with SwiftUI and Core Data. This is the first iteration focusing on importing and storing receipt images locally.
+
+## Features
+- List of saved receipts (initially empty).
+- **Add Receipt** button opens camera or file picker to import an image.
+- Images saved to `Application Support/<bundle id>/Receipts/` and referenced by path in Core Data.
+- Basic OCR via Vision to pre-fill vendor, date and total.
+- Detail view with full image, editable fields and delete option.
+
+## Colors
+- Background: `#0B0B0D`
+- Surface: `#121214`
+- Accent Primary: `#FF5A00`
+- Accent Secondary: `#FF8A33`
+- Text Primary: `#FFFFFF`
+- Text Muted: `#BDBDBD`
+
+## Local Data Model
+`Receipt` entity fields:
+- `id: UUID`
+- `vendor: String?`
+- `total: Decimal?`
+- `date: Date?`
+- `tags: [String]?`
+- `imagePath: String`
+- `createdAt: Date`
+
+## Setup & Run
+1. Open the project in Xcode 15+ on macOS Big Sur or later.
+2. Build and run the **ReceiptApp** target.
+3. Use the toolbar **Add Receipt** button to capture or choose an image.
+
+## Testing
+`ReceiptAppTests` includes a minimal Core Data save/load test.
+Run with `xcodebuild test` in Xcode or via the Test navigator.
+
+## TODO
+- Cloud sync via Supabase or S3.
+- Better OCR parsing and correction UI.

--- a/Services/ImageStore.swift
+++ b/Services/ImageStore.swift
@@ -1,0 +1,41 @@
+import Foundation
+import AppKit
+
+/// Handles saving and loading receipt images on disk.
+final class ImageStore {
+    static let shared = ImageStore()
+
+    private let directory: URL
+
+    init() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let bundleId = Bundle.main.bundleIdentifier ?? "ReceiptApp"
+        directory = appSupport.appendingPathComponent(bundleId).appendingPathComponent("Receipts")
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    /// Saves an image and returns the relative filename.
+    func saveImage(_ image: NSImage) throws -> String {
+        let name = UUID().uuidString + ".png"
+        let url = directory.appendingPathComponent(name)
+        guard let data = image.pngData else {
+            throw NSError(domain: "ImageStore", code: 0, userInfo: [NSLocalizedDescriptionKey: "PNG conversion failed"])
+        }
+        try data.write(to: url)
+        return name
+    }
+
+    /// Loads an image at the given relative path.
+    func loadImage(from path: String) -> NSImage? {
+        let url = directory.appendingPathComponent(path)
+        return NSImage(contentsOf: url)
+    }
+}
+
+extension NSImage {
+    /// Returns PNG data for the image if possible.
+    var pngData: Data? {
+        guard let tiff = tiffRepresentation, let rep = NSBitmapImageRep(data: tiff) else { return nil }
+        return rep.representation(using: .png, properties: [:])
+    }
+}

--- a/Services/OCRService.swift
+++ b/Services/OCRService.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Vision
+import AppKit
+
+/// Result of OCR parsing.
+struct OCRResult {
+    var vendor: String?
+    var total: Decimal?
+    var date: Date?
+}
+
+/// Performs basic OCR on receipt images using Vision.
+final class OCRService {
+    func extract(from image: NSImage, completion: @escaping (OCRResult) -> Void) {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            completion(OCRResult())
+            return
+        }
+        let request = VNRecognizeTextRequest { request, _ in
+            var result = OCRResult()
+            if let observations = request.results as? [VNRecognizedTextObservation] {
+                let lines = observations.compactMap { $0.topCandidates(1).first?.string }
+                result.vendor = self.detectVendor(in: lines)
+                result.total = self.detectTotal(in: lines)
+                result.date = self.detectDate(in: lines)
+            }
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
+        request.recognitionLevel = .accurate
+        let handler = VNImageRequestHandler(cgImage: cgImage)
+        DispatchQueue.global(qos: .userInitiated).async {
+            try? handler.perform([request])
+        }
+    }
+
+    private func detectVendor(in lines: [String]) -> String? {
+        return lines.first
+    }
+
+    private func detectTotal(in lines: [String]) -> Decimal? {
+        let pattern = "(total|amount)\\D*(\\d+[.,]\\d{2})"
+        let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+        for line in lines {
+            if let match = regex?.firstMatch(in: line, options: [], range: NSRange(location: 0, length: line.count)),
+               let range = Range(match.range(at: 2), in: line) {
+                let number = line[range].replacingOccurrences(of: ",", with: ".")
+                return Decimal(string: number)
+            }
+        }
+        return nil
+    }
+
+    private func detectDate(in lines: [String]) -> Date? {
+        let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.date.rawValue)
+        for line in lines {
+            if let match = detector?.firstMatch(in: line, options: [], range: NSRange(location: 0, length: line.count)),
+               let date = match.date {
+                return date
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/Color+Extensions.swift
+++ b/Sources/Color+Extensions.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Utility initialiser to create Color from hex string.
+extension Color {
+    init(hex: String) {
+        let scanner = Scanner(string: hex)
+        _ = scanner.scanString("#")
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+        let r = Double((rgb >> 16) & 0xFF) / 255
+        let g = Double((rgb >> 8) & 0xFF) / 255
+        let b = Double(rgb & 0xFF) / 255
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+/// App colour palette.
+extension Color {
+    static let background = Color(hex: "#0B0B0D")
+    static let surface = Color(hex: "#121214")
+    static let accentPrimary = Color(hex: "#FF5A00")
+    static let accentSecondary = Color(hex: "#FF8A33")
+    static let textPrimary = Color(hex: "#FFFFFF")
+    static let textMuted = Color(hex: "#BDBDBD")
+}

--- a/Sources/Persistence.swift
+++ b/Sources/Persistence.swift
@@ -1,0 +1,29 @@
+import CoreData
+
+/// Handles Core Data stack for the application.
+struct PersistenceController {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        container = NSPersistentContainer(name: "ReceiptModel")
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Unresolved error \(error)")
+            }
+        }
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+    }
+
+    /// Saves changes in the view context if needed.
+    func save() {
+        let context = container.viewContext
+        if context.hasChanges {
+            try? context.save()
+        }
+    }
+}

--- a/Sources/ReceiptApp.swift
+++ b/Sources/ReceiptApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@main
+struct ReceiptApp: App {
+    let persistenceController = PersistenceController.shared
+
+    var body: some Scene {
+        WindowGroup {
+            ReceiptListView()
+                .environment(\.managedObjectContext, persistenceController.container.viewContext)
+                .accentColor(.accentPrimary)
+                .preferredColorScheme(.dark)
+        }
+    }
+}

--- a/Sources/ReceiptViewModel.swift
+++ b/Sources/ReceiptViewModel.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import CoreData
+import Combine
+import Quartz
+
+/// View model driving receipt operations such as importing and deleting.
+final class ReceiptViewModel: ObservableObject {
+    private let context: NSManagedObjectContext
+    private let imageStore: ImageStore
+    private let ocrService = OCRService()
+
+    init(context: NSManagedObjectContext, imageStore: ImageStore = .shared) {
+        self.context = context
+        self.imageStore = imageStore
+    }
+
+    /// Opens an image picker (camera or file) and imports the resulting image as a receipt.
+    func addReceipt() {
+        let picker = IKPictureTaker()
+        picker.begin { returnCode in
+            guard returnCode == .OK, let image = picker.outputImage() else { return }
+            self.handleImport(image: image)
+        }
+    }
+
+    /// Saves image and creates a new Receipt record, running OCR to pre-fill metadata.
+    private func handleImport(image: NSImage) {
+        let imageName: String
+        do {
+            imageName = try imageStore.saveImage(image)
+        } catch {
+            print("Failed to save image: \(error)")
+            return
+        }
+        let receipt = Receipt(context: context)
+        receipt.id = UUID()
+        receipt.imagePath = imageName
+        receipt.createdAt = Date()
+        receipt.vendor = ""
+        ocrService.extract(from: image) { result in
+            receipt.vendor = result.vendor ?? receipt.vendor
+            receipt.total = result.total as NSDecimalNumber?
+            receipt.date = result.date
+            try? self.context.save()
+        }
+    }
+
+    /// Deletes a receipt from storage.
+    func delete(_ receipt: Receipt) {
+        context.delete(receipt)
+        try? context.save()
+    }
+}

--- a/Tests/ReceiptAppTests.swift
+++ b/Tests/ReceiptAppTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import CoreData
+@testable import ReceiptApp
+
+/// Minimal tests verifying Core Data persistence for receipts.
+final class ReceiptAppTests: XCTestCase {
+    func testSaveAndFetchReceipt() throws {
+        let controller = PersistenceController(inMemory: true)
+        let context = controller.container.viewContext
+        let receipt = Receipt(context: context)
+        receipt.id = UUID()
+        receipt.imagePath = "test.png"
+        receipt.createdAt = Date()
+        try context.save()
+
+        let request: NSFetchRequest<Receipt> = Receipt.fetchRequest()
+        let results = try context.fetch(request)
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.imagePath, "test.png")
+    }
+}

--- a/Views/ReceiptDetailView.swift
+++ b/Views/ReceiptDetailView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import CoreData
+
+/// Detail editor showing full image and editable fields.
+struct ReceiptDetailView: View {
+    @ObservedObject var receipt: Receipt
+    @Environment(\.managedObjectContext) private var context
+    @Environment(\.dismiss) private var dismiss
+    @State private var tagsText: String = ""
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let image = ImageStore.shared.loadImage(from: receipt.imagePath) {
+                    Image(nsImage: image)
+                        .resizable()
+                        .scaledToFit()
+                        .cornerRadius(8)
+                }
+                Form {
+                    TextField("Vendor", text: Binding($receipt.vendor, ""))
+                    TextField("Total", value: $receipt.total, formatter: NumberFormatter.currency)
+                    DatePicker("Date", selection: Binding($receipt.date, Date()), displayedComponents: .date)
+                    TextField("Tags", text: $tagsText)
+                        .onAppear { tagsText = receipt.tags?.joined(separator: ", ") ?? "" }
+                        .onChange(of: tagsText) { newValue in
+                            receipt.tags = newValue.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                        }
+                }
+                .padding()
+                HStack {
+                    Spacer()
+                    Button(role: .destructive) {
+                        context.delete(receipt)
+                        try? context.save()
+                        dismiss()
+                    } label: {
+                        Text("Delete")
+                    }
+                }
+                .padding(.bottom)
+            }
+            .padding()
+        }
+        .background(Color.surface)
+        .navigationTitle("Receipt")
+        .onDisappear { try? context.save() }
+    }
+}
+
+/// Helper to bind optional values to text fields.
+extension Binding {
+    init(_ source: Binding<Value?>, _ defaultValue: Value) {
+        self.init(
+            get: { source.wrappedValue ?? defaultValue },
+            set: { source.wrappedValue = $0 }
+        )
+    }
+}

--- a/Views/ReceiptListView.swift
+++ b/Views/ReceiptListView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import CoreData
+
+/// Displays receipts in a scrolling list with ability to add new ones.
+struct ReceiptListView: View {
+    @Environment(\.managedObjectContext) private var context
+    @StateObject private var viewModel: ReceiptViewModel
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Receipt.createdAt, ascending: false)],
+        animation: .default)
+    private var receipts: FetchedResults<Receipt>
+
+    init() {
+        let context = PersistenceController.shared.container.viewContext
+        _viewModel = StateObject(wrappedValue: ReceiptViewModel(context: context))
+        _receipts = FetchRequest(
+            sortDescriptors: [NSSortDescriptor(keyPath: \Receipt.createdAt, ascending: false)],
+            animation: .default)
+    }
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(receipts) { receipt in
+                    NavigationLink(destination: ReceiptDetailView(receipt: receipt)) {
+                        ReceiptRowView(receipt: receipt)
+                    }
+                }
+                .onDelete(perform: delete)
+            }
+            .listStyle(.inset)
+            .background(Color.background)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: viewModel.addReceipt) {
+                        Image(systemName: "plus")
+                    }
+                    .help("Add Receipt")
+                }
+            }
+        }
+    }
+
+    private func delete(offsets: IndexSet) {
+        offsets.map { receipts[$0] }.forEach(viewModel.delete)
+    }
+}
+
+/// Row representing a single receipt.
+struct ReceiptRowView: View {
+    @ObservedObject var receipt: Receipt
+
+    var body: some View {
+        HStack {
+            if let image = ImageStore.shared.loadImage(from: receipt.imagePath) {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 40, height: 40)
+                    .cornerRadius(4)
+            }
+            VStack(alignment: .leading) {
+                Text(receipt.vendor?.isEmpty == false ? receipt.vendor! : receipt.imagePath)
+                    .foregroundColor(.textPrimary)
+                if let date = receipt.date {
+                    Text(date, style: .date)
+                        .foregroundColor(.textMuted)
+                        .font(.caption)
+                }
+            }
+            Spacer()
+            if let total = receipt.total {
+                Text(NumberFormatter.currency.string(from: total) ?? "")
+                    .foregroundColor(.textPrimary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+extension NumberFormatter {
+    static let currency: NumberFormatter = {
+        let nf = NumberFormatter()
+        nf.numberStyle = .currency
+        return nf
+    }()
+}


### PR DESCRIPTION
## Summary
- scaffold SwiftUI macOS app with Core Data-backed `Receipt` model
- import receipts via camera or file and run basic Vision OCR
- list and edit saved receipts with dark theme and hot-orange accent

## Testing
- `swift test` *(fails: no such module 'CoreData' on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a92adb708333b9701e801cded872