### PR TITLE
Use presentationMode for macOS 11 dismissal

### DIFF
--- a/Views/ReceiptDetailView.swift
+++ b/Views/ReceiptDetailView.swift
@@ -5,7 +5,7 @@ import CoreData
 struct ReceiptDetailView: View {
     @ObservedObject var receipt: Receipt
     @Environment(\.managedObjectContext) private var context
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.presentationMode) private var presentationMode
     @State private var tagsText: String = ""
 
     var body: some View {
@@ -33,7 +33,7 @@ struct ReceiptDetailView: View {
                     Button(role: .destructive) {
                         context.delete(receipt)
                         try? context.save()
-                        dismiss()
+                        presentationMode.wrappedValue.dismiss()
                     } label: {
                         Text("Delete")
                     }


### PR DESCRIPTION
## Summary
- Replace `@Environment(\.dismiss)` with legacy `@Environment(\.presentationMode)` to maintain macOS 11 support
- Dismiss receipt editor using `presentationMode.wrappedValue.dismiss()`

## Testing
- ⚠️ `swift test` *(fails: no such module 'CoreData')*

------
https://chatgpt.com/codex/tasks/task_e_68a1af30d854833382e0af7da24726aa