### PR TITLE
Switch receipt totals to Decimal

### DIFF
--- a/Models/Receipt.swift
+++ b/Models/Receipt.swift
@@ -6,7 +6,7 @@ import CoreData
 public class Receipt: NSManagedObject, Identifiable {
     @NSManaged public var id: UUID
     @NSManaged public var vendor: String?
-    @NSManaged public var total: NSDecimalNumber?
+    @NSManaged public var total: Decimal?
     @NSManaged public var date: Date?
     @NSManaged public var tags: [String]?
     @NSManaged public var imagePath: String

--- a/Models/ReceiptModel.xcdatamodeld/ReceiptModel.xcdatamodel/contents
+++ b/Models/ReceiptModel.xcdatamodeld/ReceiptModel.xcdatamodel/contents
@@ -3,7 +3,7 @@
     <entity name="Receipt" representedClassName="Receipt" syncable="YES" codeGenerationType="class">
         <attribute name="id" optional="NO" attributeType="UUID"/>
         <attribute name="vendor" optional="YES" attributeType="String"/>
-        <attribute name="total" optional="YES" attributeType="Decimal"/>
+        <attribute name="total" optional="YES" attributeType="Decimal" usesScalarValueType="YES"/>
         <attribute name="date" optional="YES" attributeType="Date"/>
         <attribute name="tags" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="imagePath" optional="NO" attributeType="String"/>

--- a/Sources/ReceiptViewModel.swift
+++ b/Sources/ReceiptViewModel.swift
@@ -39,7 +39,7 @@ final class ReceiptViewModel: ObservableObject {
         receipt.vendor = ""
         ocrService.extract(from: image) { result in
             receipt.vendor = result.vendor ?? receipt.vendor
-            receipt.total = result.total as NSDecimalNumber?
+            receipt.total = result.total
             receipt.date = result.date
             try? self.context.save()
         }

--- a/Views/ReceiptDetailView.swift
+++ b/Views/ReceiptDetailView.swift
@@ -19,7 +19,7 @@ struct ReceiptDetailView: View {
                 }
                 Form {
                     TextField("Vendor", text: Binding($receipt.vendor, ""))
-                    TextField("Total", value: $receipt.total, formatter: NumberFormatter.currency)
+                    TextField("Total", value: Binding($receipt.total, Decimal(0)), formatter: NumberFormatter.currency)
                     DatePicker("Date", selection: Binding($receipt.date, Date()), displayedComponents: .date)
                     TextField("Tags", text: $tagsText)
                         .onAppear { tagsText = receipt.tags?.joined(separator: ", ") ?? "" }

--- a/Views/ReceiptListView.swift
+++ b/Views/ReceiptListView.swift
@@ -70,7 +70,7 @@ struct ReceiptRowView: View {
             }
             Spacer()
             if let total = receipt.total {
-                Text(NumberFormatter.currency.string(from: total) ?? "")
+                Text(NumberFormatter.currency.string(for: total) ?? "")
                     .foregroundColor(.textPrimary)
             }
         }


### PR DESCRIPTION
## Summary
- store receipt totals as `Decimal` instead of `NSDecimalNumber`
- wire up detail and list views to use the numeric total with `NumberFormatter.currency`
- save OCR totals directly as `Decimal`

## Testing
- `swift test` *(fails: no such module 'CoreData')*


------
https://chatgpt.com/codex/tasks/task_e_68a1af35d7548333b7777acd3ab5fe3b