### PR TITLE
Make Receipt ID optional

### DIFF
--- a/Models/Receipt.swift
+++ b/Models/Receipt.swift
@@ -4,7 +4,7 @@ import CoreData
 /// Core Data entity representing a receipt.
 @objc(Receipt)
 public class Receipt: NSManagedObject, Identifiable {
-    @NSManaged public var id: UUID
+    @NSManaged public var id: UUID?
     @NSManaged public var vendor: String?
     @NSManaged public var total: NSDecimalNumber?
     @NSManaged public var date: Date?

--- a/Models/ReceiptModel.xcdatamodeld/ReceiptModel.xcdatamodel/contents
+++ b/Models/ReceiptModel.xcdatamodeld/ReceiptModel.xcdatamodel/contents
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17710" systemVersion="20A2408" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Receipt" representedClassName="Receipt" syncable="YES" codeGenerationType="class">
-        <attribute name="id" optional="NO" attributeType="UUID"/>
+        <attribute name="id" optional="YES" attributeType="UUID"/>
         <attribute name="vendor" optional="YES" attributeType="String"/>
         <attribute name="total" optional="YES" attributeType="Decimal"/>
         <attribute name="date" optional="YES" attributeType="Date"/>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Minimal macOS receipt tracker built with SwiftUI and Core Data. This is the firs
 
 ## Local Data Model
 `Receipt` entity fields:
-- `id: UUID`
+- `id: UUID?`
 - `vendor: String?`
 - `total: Decimal?`
 - `date: Date?`


### PR DESCRIPTION
## Summary
- allow `Receipt.id` to be nil by switching property and data model to optional
- document optional `id` in README

## Testing
- `swift test` *(fails: no such module 'CoreData')*

------
https://chatgpt.com/codex/tasks/task_e_68a1af3a91408333bc7502f00e0c1a90