### PR TITLE
Restrict ReceiptListView to AppKit platforms

### DIFF
--- a/Views/ReceiptListView.swift
+++ b/Views/ReceiptListView.swift
@@ -1,6 +1,7 @@
-#if canImport(SwiftUI) && canImport(CoreData)
+#if canImport(SwiftUI) && canImport(CoreData) && canImport(AppKit)
 import SwiftUI
 import CoreData
+import AppKit
 
 /// Displays receipts in a scrolling list with ability to add new ones.
 struct ReceiptListView: View {


### PR DESCRIPTION
## Summary
- guard ReceiptListView behind AppKit availability and import AppKit

## Testing
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1b5fa2b388333b310dae5638f1bf6