### PR TITLE
Remove unused context from ReceiptListView

### DIFF
--- a/Views/ReceiptListView.swift
+++ b/Views/ReceiptListView.swift
@@ -4,7 +4,6 @@ import CoreData
 
 /// Displays receipts in a scrolling list with ability to add new ones.
 struct ReceiptListView: View {
-    @Environment(\.managedObjectContext) private var context
     @StateObject private var viewModel: ReceiptViewModel
     @FetchRequest(
         sortDescriptors: [NSSortDescriptor(keyPath: \Receipt.createdAt, ascending: false)],


### PR DESCRIPTION
## Summary
- Delete unused managed object context environment property

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b5fd63dc8333ad5d22e0de5c8f0b